### PR TITLE
[GC] Added option to collect garbage before timeout expires

### DIFF
--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -27,60 +27,37 @@
 #include "lj_strfmt.h"
 
 #include <time.h>
-#if LJ_TARGET_POSIX
-#include <sys/time.h>
-#elif LJ_TARGET_WINDOWS
-#define timercmp(a, b, CMP)                              \
-  (((a)->tv_sec == (b)->tv_sec) ?                        \
-   ((a)->tv_nsec CMP (b)->tv_nsec) :                    \
-   ((a)->tv_sec CMP (b)->tv_sec))
-#define timeradd(a, b, result)                                   \
-  do {                                                                         \
-    (result)->tv_sec = (a)->tv_sec + (b)->tv_sec;         \
-    (result)->tv_nsec = (a)->tv_nsec + (b)->tv_nsec;    \
-    if ((result)->tv_nsec >= 1000000000)                \
-      {                                                 \
-        ++(result)->tv_sec;                             \
-        (result)->tv_nsec -= 1000000000;                \
-      }                                                 \
-  } while (0)
+
+#if LJ_TARGET_WINDOWS
+static inline uint64_t get_query_performance_counter(void)
+{
+  LARGE_INTEGER cnt;
+  QueryPerformanceCounter(&cnt);
+  return cnt.QuadPart;
+}
+#elif LJ_TARGET_POSIX
+static inline uint64_t get_query_performance_counter(void)
+{
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+  return 1000000000ULL * ts.tv_sec + ts.tv_nsec;
+}
 #endif
 
 static void gc_step_timeout(lua_State *L, uint32_t timeout_usec)
 {
-#if LJ_TARGET_POSIX
-  struct timeval tv_timeout;
-  tv_timeout.tv_sec = 0;
-  tv_timeout.tv_usec = timeout_usec;
+  uint64_t timeout = timeout_usec * 1000;
 
-  struct timeval tv_current;
-  gettimeofday(&tv_current, NULL);
+  uint64_t time_current = get_query_performance_counter();
 
-  timeradd(&tv_current, &tv_timeout, &tv_timeout);
-  while (timercmp(&tv_current, &tv_timeout, <)) {
+  timeout += time_current;
+  while (time_current < timeout) {
     if (lj_gc_step(L) > 0) {
       break;
     }
 
-    gettimeofday(&tv_current, NULL);
+    time_current = get_query_performance_counter();
   }
-#elif LJ_TARGET_WINDOWS
-  struct timespec tv_timeout;
-  tv_timeout.tv_sec = 0;
-  tv_timeout.tv_nsec = timeout_usec * 1000;
-
-  struct timespec tv_current;
-  timespec_get(&tv_current, TIME_UTC);
-
-  timeradd(&tv_current, &tv_timeout, &tv_timeout);
-  while (timercmp(&tv_current, &tv_timeout, < )) {
-    if (lj_gc_step(L) > 0) {
-      break;
-    }
-
-    timespec_get(&tv_current, TIME_UTC);
-  }
-#endif
 }
 
 /* -- Common helper functions --------------------------------------------- */

--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -1347,13 +1347,12 @@ LUA_API int lua_gc(lua_State *L, int what, int data)
       }
     break;
   }
-  case LUA_GCTIMEOUT: {
+  case LUA_GCTIMEOUT:
     res = gc_step_timeout(L, (uint32_t)data);
     if (res >= 0) {
       g->gc.threshold = LJ_MAX_MEM;
     }
     break;
-  }
   case LUA_GCSETPAUSE:
     res = (int)(g->gc.pause);
     g->gc.pause = (MSize)data;

--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -31,14 +31,14 @@
 #endif
 
 #if LJ_TARGET_WINDOWS
-static inline uint64_t get_query_performance_counter(void)
+static inline uint64_t get_high_resolution_time(void)
 {
   LARGE_INTEGER cnt;
   QueryPerformanceCounter(&cnt);
   return cnt.QuadPart;
 }
 #elif LJ_TARGET_POSIX
-static inline uint64_t get_query_performance_counter(void)
+static inline uint64_t get_high_resolution_time(void)
 {
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
@@ -52,7 +52,7 @@ static int gc_step_timeout(lua_State *L, uint32_t timeout_usec)
   int res = 0;
   uint64_t timeout = timeout_usec * 1000;
 
-  uint64_t time_current = get_query_performance_counter();
+  uint64_t time_current = get_high_resolution_time();
 
   timeout += time_current;
   while (time_current < timeout) {
@@ -61,7 +61,7 @@ static int gc_step_timeout(lua_State *L, uint32_t timeout_usec)
       break;
     }
 
-    time_current = get_query_performance_counter();
+    time_current = get_high_resolution_time();
   }
   return res;
 #else

--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -26,7 +26,9 @@
 #include "lj_strscan.h"
 #include "lj_strfmt.h"
 
+#if LJ_TARGET_POSIX
 #include <time.h>
+#endif
 
 #if LJ_TARGET_WINDOWS
 static inline uint64_t get_query_performance_counter(void)

--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -44,8 +44,10 @@ static inline uint64_t get_query_performance_counter(void)
 }
 #endif
 
-static void gc_step_timeout(lua_State *L, uint32_t timeout_usec)
+static int gc_step_timeout(lua_State *L, uint32_t timeout_usec)
 {
+#if LJ_TARGET_WINDOWS || LJ_TARGET_POSIX
+  int res = 0;
   uint64_t timeout = timeout_usec * 1000;
 
   uint64_t time_current = get_query_performance_counter();
@@ -53,11 +55,16 @@ static void gc_step_timeout(lua_State *L, uint32_t timeout_usec)
   timeout += time_current;
   while (time_current < timeout) {
     if (lj_gc_step(L) > 0) {
+      res = 1;
       break;
     }
 
     time_current = get_query_performance_counter();
   }
+  return res;
+#else
+  return -1;
+#endif
 }
 
 /* -- Common helper functions --------------------------------------------- */
@@ -1339,8 +1346,10 @@ LUA_API int lua_gc(lua_State *L, int what, int data)
     break;
   }
   case LUA_GCTIMEOUT: {
-    gc_step_timeout(L, (uint32_t)data);
-    g->gc.threshold = LJ_MAX_MEM;
+    res = gc_step_timeout(L, (uint32_t)data);
+    if (res >= 0) {
+      g->gc.threshold = LJ_MAX_MEM;
+    }
     break;
   }
   case LUA_GCSETPAUSE:

--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -26,6 +26,63 @@
 #include "lj_strscan.h"
 #include "lj_strfmt.h"
 
+#include <time.h>
+#if LJ_TARGET_POSIX
+#include <sys/time.h>
+#elif LJ_TARGET_WINDOWS
+#define timercmp(a, b, CMP)                              \
+  (((a)->tv_sec == (b)->tv_sec) ?                        \
+   ((a)->tv_nsec CMP (b)->tv_nsec) :                    \
+   ((a)->tv_sec CMP (b)->tv_sec))
+#define timeradd(a, b, result)                                   \
+  do {                                                                         \
+    (result)->tv_sec = (a)->tv_sec + (b)->tv_sec;         \
+    (result)->tv_nsec = (a)->tv_nsec + (b)->tv_nsec;    \
+    if ((result)->tv_nsec >= 1000000000)                \
+      {                                                 \
+        ++(result)->tv_sec;                             \
+        (result)->tv_nsec -= 1000000000;                \
+      }                                                 \
+  } while (0)
+#endif
+
+static void gc_step_timeout(lua_State *L, uint32_t timeout_usec)
+{
+#if LJ_TARGET_POSIX
+  struct timeval tv_timeout;
+  tv_timeout.tv_sec = 0;
+  tv_timeout.tv_usec = timeout_usec;
+
+  struct timeval tv_current;
+  gettimeofday(&tv_current, NULL);
+
+  timeradd(&tv_current, &tv_timeout, &tv_timeout);
+  while (timercmp(&tv_current, &tv_timeout, <)) {
+    if (lj_gc_step(L) > 0) {
+      break;
+    }
+
+    gettimeofday(&tv_current, NULL);
+  }
+#elif LJ_TARGET_WINDOWS
+  struct timespec tv_timeout;
+  tv_timeout.tv_sec = 0;
+  tv_timeout.tv_nsec = timeout_usec * 1000;
+
+  struct timespec tv_current;
+  timespec_get(&tv_current, TIME_UTC);
+
+  timeradd(&tv_current, &tv_timeout, &tv_timeout);
+  while (timercmp(&tv_current, &tv_timeout, < )) {
+    if (lj_gc_step(L) > 0) {
+      break;
+    }
+
+    timespec_get(&tv_current, TIME_UTC);
+  }
+#endif
+}
+
 /* -- Common helper functions --------------------------------------------- */
 
 #define lj_checkapi_slot(idx) \
@@ -1299,9 +1356,14 @@ LUA_API int lua_gc(lua_State *L, int what, int data)
     g->gc.threshold = (a <= g->gc.total) ? (g->gc.total - a) : 0;
     while (g->gc.total >= g->gc.threshold)
       if (lj_gc_step(L) > 0) {
-	res = 1;
-	break;
+        res = 1;
+        break;
       }
+    break;
+  }
+  case LUA_GCTIMEOUT: {
+    gc_step_timeout(L, (uint32_t)data);
+    g->gc.threshold = LJ_MAX_MEM;
     break;
   }
   case LUA_GCSETPAUSE:

--- a/src/lua.h
+++ b/src/lua.h
@@ -228,6 +228,7 @@ LUA_API int  (lua_status) (lua_State *L);
 #define LUA_GCSETPAUSE		6
 #define LUA_GCSETSTEPMUL	7
 #define LUA_GCISRUNNING		9
+#define LUA_GCTIMEOUT		10
 
 LUA_API int (lua_gc) (lua_State *L, int what, int data);
 


### PR DESCRIPTION
lua_gc now supports LUA_GCTIMEOUT option, which collects all garbage it can until selected timeout in microseconds.

Result codes:
-1 – unsupported platform
0 – exit by timeout
1 – garbage collection is fully finished

The option significantly improves FPS stability. 