### PR TITLE
e2k: fix errors found on penlight and luaposix

### DIFF
--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1772,7 +1772,6 @@ static void build_subroutines(BuildCtx *ctx)
     | // 0/1 or TValue * (metamethod) returned.
     | cmpbedb   0, CRET1, 0x1, pred0
     | cmpbdb    1, CRET1, 0x1, pred1
-    | addd      2, S1, 0x4, S1
     | ldd       3, RB, L->base, BASE
     | disp      ctpr2, ->vmeta_binop
     | wait      ctpr2, 0, 5
@@ -5131,7 +5130,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         case BC_ISTC:
         | ldd       2, RARG1, DISPATCH, RARG1   // Load dispath for branch target.
         | addd      4, T2, T1, PC, pred0
-        | std       5, BASE, RA_W, RD
+        | std       5, BASE, RA_W, RD, pred0
         | --
         | wait_load RARG1, 1
         | ct        ctpr1, pred0            // vm_restart_pipeline_fast(RARG1)
@@ -5140,7 +5139,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         case BC_ISFC:
         | ldd       2, RARG1, DISPATCH, RARG1   // Load dispath for branch target.
         | addd      3, T2, T1, PC, ~pred0
-        | std       5, BASE, RA_W, RD
+        | std       5, BASE, RA_W, RD, ~pred0
         | --
         | wait_load RARG1, 1
         | ct        ctpr1, ~pred0           // vm_restart_pipeline_fast(RARG1)
@@ -6554,7 +6553,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // TODO: convert to standard calling convention
         | shld      3, S1, 0x5, S0
         | shld      4, S1, 0x3, S1
-        | disp      ctpr1, <1
+        | disp      ctpr1, >1
         | --
         | subd      3, S0, S1, S1           // idx*32 - idx*8 = idx * #NODE (24)
         | disp      ctpr2, >2
@@ -6780,12 +6779,13 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass      pred1, p0
         | pass      pred2, p1
         | pass      pred3, p2
-        | landp     p0, p1, p4              // Is key a generic number?
-        | landp     ~p4, ~p2, p5            // Is key a generic number or a string?
-        | pass      p5, pred0
+        | landp     p0, ~p1, p4
+        | landp     ~p0, ~p2, p5
+        | landp     ~p4, ~p5, p6
+        | pass      p6, pred0
         | wait_pred_ct pred0, 0
         | --
-        | ct        ctpr1, pred0            // vmeta_tsetv, key is not a generic number or a string.
+        | ct        ctpr1, ~pred0           // vmeta_tsetv, key is not a generic number or a string.
         | --
         | extract_value_if 3, RC, RC, ~pred1
         | sxt       4, 0x2, S0, RC, pred2


### PR DESCRIPTION
Hello.

Fixed some bugs for e2k interpreter:
1) Rare case with vmeta for TGETS/TGETV.
2) Lost data in ISFC/ISTC.